### PR TITLE
FEATURE: Allow to geocode only fe_users with no lat or lng

### DIFF
--- a/Classes/Command/GeocodeCommandController.php
+++ b/Classes/Command/GeocodeCommandController.php
@@ -52,11 +52,27 @@ class GeocodeCommandController extends CommandController
     /**
      * Geocode all fe_users entries if possible.
      */
-    public function feUserCommand()
+    public function allFeUserCommand()
     {
-        $this->logger->info('Adding geocoding information to fe_users.');
+        $this->geocodeFeUsers($this->getFeUsers());
+    }
 
-        foreach ($this->getFeUsers() as $user) {
+    /**
+     * Geocode all fe_users entries with no lat or no lon, if possible.
+     */
+    public function missingFeUserCommand()
+    {
+        $this->geocodeFeUsers($this->getFeUsers("lat = '' OR lat is null OR lng = '' OR lng is null"));
+    }
+
+    protected function geocodeFeUsers(array $feUsers)
+    {
+        $this->logger->info(sprintf(
+            'Adding geocoding information to %u fe_users.',
+            count($feUsers)
+        ));
+
+        foreach ($feUsers as $user) {
             $this->logger->info(sprintf(
                 'Geocoding fe_user "%s" with address "%s".',
                 $user['username'],
@@ -86,11 +102,12 @@ class GeocodeCommandController extends CommandController
         }
     }
 
-    protected function getFeUsers() : array
+    protected function getFeUsers(string $where = '1=1') : array
     {
         return $this->connection
             ->getQueryBuilderForTable('fe_users')
             ->select('*')
+            ->where($where)
             ->from('fe_users')
             ->execute()
             ->fetchAll();

--- a/Tests/Functional/Fixture/GeocodeAllFeUser.xml
+++ b/Tests/Functional/Fixture/GeocodeAllFeUser.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<dataset>
+    <fe_users>
+        <uid>1</uid>
+        <pid>0</pid>
+        <username>some_username</username>
+        <name>Max Mustermann</name>
+        <address>Wilhelmstr. 35</address>
+        <zip>52070</zip>
+        <city>Aachen</city>
+        <country>Deutschland</country>
+        <lat></lat>
+        <lng></lng>
+    </fe_users>
+    <fe_users>
+        <uid>2</uid>
+        <pid>0</pid>
+        <username>another_username</username>
+        <name>Max Mustermann</name>
+        <address>Wilhelmstr. 35</address>
+        <zip>52070</zip>
+        <city>Aachen</city>
+        <country>Deutschland</country>
+        <lat></lat>
+        <lng></lng>
+    </fe_users>
+</dataset>

--- a/Tests/Functional/Fixture/GeocodeMissingFeUser.xml
+++ b/Tests/Functional/Fixture/GeocodeMissingFeUser.xml
@@ -9,6 +9,18 @@
         <zip>52070</zip>
         <city>Aachen</city>
         <country>Deutschland</country>
+        <lat>51</lat>
+        <lng>56</lng>
+    </fe_users>
+    <fe_users>
+        <uid>2</uid>
+        <pid>0</pid>
+        <username>another_username</username>
+        <name>Max Mustermann</name>
+        <address>Wilhelmstr. 35</address>
+        <zip>52070</zip>
+        <city>Aachen</city>
+        <country>Deutschland</country>
         <lat></lat>
         <lng></lng>
     </fe_users>


### PR DESCRIPTION
This way it's possible to geocode another batch at another day, when
query limit is available again.