### PR TITLE
Hotfix: Handle inactive users

### DIFF
--- a/Classes/Hook/DataMapHook.php
+++ b/Classes/Hook/DataMapHook.php
@@ -17,7 +17,6 @@ namespace Codappix\CdxFeuserLocations\Hook;
 use Codappix\CdxFeuserLocations\Service\Geocode;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
-use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageQueue;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;

--- a/Classes/Hook/DataMapHook.php
+++ b/Classes/Hook/DataMapHook.php
@@ -15,8 +15,9 @@ namespace Codappix\CdxFeuserLocations\Hook;
  */
 
 use Codappix\CdxFeuserLocations\Service\Geocode;
-use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageQueue;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
@@ -51,9 +52,9 @@ class DataMapHook
     protected $geocode = null;
 
     /**
-     * @var Connection
+     * @var QueryBuilder
      */
-    protected $dbConnection = null;
+    protected $queryBuilder = null;
 
     /**
      * @var FlashMessageQueue
@@ -77,8 +78,9 @@ class DataMapHook
         }
 
         $this->geocode = $geocode;
-        $this->dbConnection = $connectionPool->getConnectionForTable($this->tableToProcess);
         $this->flashMessageQueue = $flashMessageService->getMessageQueueByIdentifier();
+        $this->queryBuilder = $connectionPool->getQueryBuilderForTable($this->tableToProcess);
+        $this->queryBuilder->getRestrictions()->removeAll();
     }
 
     /**
@@ -147,11 +149,13 @@ class DataMapHook
 
     protected function getFullUser(array $modifiedFields, int $uid) : array
     {
-        $fullUser = $this->dbConnection->select(
-            $this->fieldsTriggerUpdate,
-            $this->tableToProcess,
-            ['uid' => (int) $uid]
-        )->fetch();
+        $fullUser = $this->queryBuilder
+            ->select(...  $this->fieldsTriggerUpdate)
+            ->from($this->tableToProcess)
+            ->where('uid = :uid')
+            ->setParameter('uid', (int) $uid)
+            ->execute()
+            ->fetch();
 
         ArrayUtility::mergeRecursiveWithOverrule($fullUser, $modifiedFields);
 

--- a/Tests/Functional/Command/GeocodeCommandControllerTest.php
+++ b/Tests/Functional/Command/GeocodeCommandControllerTest.php
@@ -35,8 +35,6 @@ class GeocodeCommandControllerTest extends FunctionalTestCase
      */
     public function geocodedInformationIsAddedToAllFeUsers()
     {
-        $this->markTestIncomplete('We do not get the test to be working all the time.');
-
         $this->importDataSet(__DIR__ . '/../Fixture/GeocodeAllFeUser.xml');
         $subject = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ObjectManager::class)
             ->get(GeocodeCommandController::class);
@@ -50,8 +48,8 @@ class GeocodeCommandControllerTest extends FunctionalTestCase
             ->fetchAll();
 
         foreach ($users as $user) {
-            $this->assertGreaterThan(0, (float) $user['lat'], 'No latitude was assigned to user "' . $user['username'] . '".');
-            $this->assertGreaterThan(0, (float) $user['lng'], 'No longitude was assigned to user "' . $user['username'] . '".');
+            $this->assertGreaterThan(0.0, (float) $user['lat'], 'No latitude was assigned to user "' . $user['username'] . '".');
+            $this->assertGreaterThan(0.0, (float) $user['lng'], 'No longitude was assigned to user "' . $user['username'] . '".');
         }
     }
 
@@ -60,8 +58,6 @@ class GeocodeCommandControllerTest extends FunctionalTestCase
      */
     public function geocodedInformationIsAddedToMissingFeUsers()
     {
-        $this->markTestIncomplete('We do not get the test to be working all the time.');
-
         $this->importDataSet(__DIR__ . '/../Fixture/GeocodeMissingFeUser.xml');
         $subject = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ObjectManager::class)
             ->get(GeocodeCommandController::class);
@@ -86,7 +82,7 @@ class GeocodeCommandControllerTest extends FunctionalTestCase
             ->execute()
             ->fetchAll();
 
-        $this->assertGreaterThan(0, (float) $user[0]['lat'], 'No latitude was assigned to user.');
-        $this->assertGreaterThan(0, (float) $user[0]['lng'], 'No longitude was assigned to user.');
+        $this->assertGreaterThan(0.0, (float) $user[0]['lat'], 'No latitude was assigned to user.');
+        $this->assertGreaterThan(0.0, (float) $user[0]['lng'], 'No longitude was assigned to user.');
     }
 }

--- a/Tests/Functional/Fixture/GeocodeAllFeUser.xml
+++ b/Tests/Functional/Fixture/GeocodeAllFeUser.xml
@@ -24,4 +24,30 @@
         <lat></lat>
         <lng></lng>
     </fe_users>
+    <fe_users>
+        <uid>3</uid>
+        <pid>0</pid>
+        <disable>1</disable>
+        <username>another_username</username>
+        <name>Max Mustermann</name>
+        <address>Wilhelmstr. 35</address>
+        <zip>52070</zip>
+        <city>Aachen</city>
+        <country>Deutschland</country>
+        <lat></lat>
+        <lng></lng>
+    </fe_users>
+    <fe_users>
+        <uid>4</uid>
+        <pid>0</pid>
+        <deleted>1</deleted>
+        <username>another_username</username>
+        <name>Max Mustermann</name>
+        <address>Wilhelmstr. 35</address>
+        <zip>52070</zip>
+        <city>Aachen</city>
+        <country>Deutschland</country>
+        <lat></lat>
+        <lng></lng>
+    </fe_users>
 </dataset>


### PR DESCRIPTION
E.g. if you edit a hidden user, the hook will not find the data and end
with an PHP error.
We therefore remove the restrictions by TYPO3 and ignore enable fields
to retrieve user record data.